### PR TITLE
build: fix build with gcc 7

### DIFF
--- a/iopc/iopc-lex.l
+++ b/iopc/iopc-lex.l
@@ -499,8 +499,8 @@ SCHARS  [.=:,;()\[\]{}?*\-_~\^/+%&|]
                           BEGIN(yyextra->dox_inline_comment ? DOX_LINE_COMMENT
                                                             : DOX_COMMENT);
                         }
-    {EOL}               |
-    <<EOF>>             { ERROR("unterminated doxygen param"); }
+    {EOL}               { ERROR("unterminated doxygen param"); }
+    <<EOF>>             { ERROR("unterminated doxygen param at EOF"); }
     .|^","|","{HS}*","  {
                           qv_t(dox_chunk) *chunks = &yyextra->tk->dox->chunks;
                           dox_chunk_t *chunk = tab_last(chunks);


### PR DESCRIPTION
When building the generated source from flex using gcc 7, there is a
warning about an implicit fallthrough:

```
iopc/iopc-lex.c: In function ‘iopc_lex’:
iopc/iopc-lex.l:267:19: error: this statement may fall through [-Werror=implicit-fallthrough=]
     yyextra->len  = yyleng;
iopc/iopc-lex.c:1507:2: note: in expansion of macro ‘YY_USER_ACTION’
 #endif
  ^~~
iopc/iopc-lex.l:503:1: note: in expansion of macro ‘YY_RULE_SETUP’
     <<EOF>>             { ERROR("unterminated doxygen param"); }
 ^   ~~~
iopc/iopc-lex.l:504:1: note: here
     .|^","|","{HS}*","  {
 ^
cc1: all warnings being treated as errors
```

Interestingly, gcc 8 doesn't complain about this fallthrough. To fix that,
we simply define two separate error messages to avoid relying on an
implicit fallthrough.